### PR TITLE
Add assertions for number of tasks in TaskList

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -35,6 +35,8 @@ public class Duke {
         storage = new Storage(filePath);
         try {
             tasks = new TaskList(storage.load());
+            // Assert that task numbers are not negative
+            assert tasks.getNumOfTasks() >= 0;
         } catch (DukeException e) {
             ui.showLoadingError();
             tasks = new TaskList();

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -192,4 +192,12 @@ public class TaskList {
             }
         }
     }
+
+    /**
+     * Getter for number of tasks currently registered
+     */
+    public int getNumOfTasks() {
+        return this.numOfTasks;
+    }
+
 }


### PR DESCRIPTION
Loading tasks from previous iterations create new TaskList object that increments numOfTask variable as it loads task. This could be affected if saved tasks are corrupted or task deletion happens when despite having no tasks left. Negative numOfTasks could result in errors when saving tasks.

This assertion ensures that numOfTasks are never negative and load and save of tasks happen properly.